### PR TITLE
Revert "Eliminate (node) warning: possible EventEmitter memory leak detecte"

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,6 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2;
 var Promise = require("bluebird");
 var _ = require("lodash");
 
-// Eliminate (node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
-EventEmitter2.setMaxListeners(50);
-
 var longpoll = function(app, opts) {
 
     // Default Config


### PR DESCRIPTION
Reverts yehya/express-longpoll#4

```
TypeError: EventEmitter2.setMaxListeners is not a function
    at Object.<anonymous> (/home/ubuntu/workspace/express-longpoll/index.js:6:15)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/ubuntu/workspace/express-longpoll/test/index.js:11:16)
    at Module._compile (module.js:409:26)
```