### PR TITLE
Handling array middleware case, fix eventemitter memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ var longpoll = function(app, opts) {
 
         // Create a new longpoll
         create: function(url, middleware, opts) {
-            if (typeof middleware === "function") {
+            if (typeof middleware === "function" || Array.isArray(middleware)) {
                 return this._createWithId(url, middleware, opts);
             }
             else {

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ var longpoll = function(app, opts) {
                         eventId = eventId + "." + req.id;
                         // Clear all previous events for the ID, we only need one
                         log("Old Events cleared: ", url, eventId);
-                        dispatcher.removeAllListeners([eventId]);
+                        dispatcher.removeAllListeners(eventId);
                     }
 
                     // Method that Creates event listener


### PR DESCRIPTION
This pull request includes two commits.

b42cdb8 handles case of array middleware.
1ff2bc0 handles eventemitter memory leak when using req.id to use publishToId.

It will be thankful if you check and test this pull request.

Thank you for good library to use.